### PR TITLE
Suppress Insecure SSL request warnings in output

### DIFF
--- a/misp-testbench.py
+++ b/misp-testbench.py
@@ -11,6 +11,10 @@ import xmlrunner
 from requests import HTTPError, ConnectionError, ConnectTimeout
 from pymisp import PyMISP, MISPOrganisation, MISPUser, MISPEvent, MISPAttribute, PyMISPError
 
+# Deactivate InsecureRequestWarnings
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
 def readInSettings():
     try:
         with open("settings.json", "r") as settings_file:


### PR DESCRIPTION
This patch removes the insecure warnings in the test output. This warnings are there because if you start MISP-dockerized it has only an self-signed certificate.